### PR TITLE
test(auth): E2E auth flows — login, signup, logout, admin access & denial, password reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/playwright-report
+/playwright/.auth
+/test-results
 
 # next.js
 /.next/

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,24 @@
+/**
+ * Auth setup: authenticates once as the test user and saves the browser storage
+ * state (cookies + localStorage) to disk so that subsequent test projects can
+ * skip the login flow entirely.
+ *
+ * Run order in playwright.config.ts:
+ *   setup → chromium (uses saved storageState)
+ *
+ * The auth-flows project intentionally does NOT depend on this setup so that
+ * auth tests always start from an unauthenticated state.
+ */
+import { test as setup, expect } from '@playwright/test';
+import { mkdirSync } from 'fs';
+import path from 'path';
+import { loginAs, TEST_USER } from './fixtures/auth';
+
+export const AUTH_FILE = path.join(__dirname, '../playwright/.auth/user.json');
+
+setup('authenticate as test user', async ({ page }) => {
+  mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
+  await loginAs(page, TEST_USER.email, TEST_USER.password);
+  await expect(page).toHaveURL(/\/dashboard/);
+  await page.context().storageState({ path: AUTH_FILE });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * End-to-end tests for all authentication flows:
+ *   - Login (valid, wrong password, non-existent email, empty fields)
+ *   - Signup (valid new account, duplicate email, weak password, mismatched passwords, empty)
+ *   - Logout (clears session → /login)
+ *   - Session persistence (survives page reload)
+ *   - Admin access (admin user allowed, non-admin and unauthenticated denied)
+ *   - Forgot password (known email, unknown email — no user enumeration)
+ *
+ * These tests intentionally run WITHOUT stored session state so that every auth
+ * interaction is tested from scratch. See playwright.config.ts for project setup.
+ *
+ * Credentials are read from env vars (TEST_USER_EMAIL / TEST_USER_PASSWORD)
+ * with fallback to the default test account defined in e2e/fixtures/auth.ts.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAs, TEST_USER } from './fixtures/auth';
+
+// ─── Login ────────────────────────────────────────────────────────────────────
+
+test.describe('Login', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('valid credentials redirect to /dashboard', async ({ page }) => {
+    await page.locator('#email').fill(TEST_USER.email);
+    await page.locator('#password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('wrong password shows error message', async ({ page }) => {
+    await page.locator('#email').fill(TEST_USER.email);
+    await page.locator('#password').fill('wrong_password_xyz');
+    await page.getByRole('button', { name: 'Login' }).click();
+    // Wait for the request to complete (button re-enables) before asserting error
+    await expect(page.getByRole('button', { name: 'Login' })).toBeEnabled({ timeout: 15_000 });
+    await expect(page.locator('.bg-red-50')).toBeVisible();
+  });
+
+  test('non-existent email shows error message', async ({ page }) => {
+    await page.locator('#email').fill('nobody@nonexistent.example.com');
+    await page.locator('#password').fill('somepassword123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('empty fields prevent submission (browser validation)', async ({ page }) => {
+    await page.getByRole('button', { name: 'Login' }).click();
+    // HTML5 required attributes prevent form submission; URL stays on /login
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+// ─── Signup ───────────────────────────────────────────────────────────────────
+
+test.describe('Signup', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/signup');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('valid new account redirects to /dashboard', async ({ page }) => {
+    // Use a timestamp-based email to avoid duplicate conflicts across runs
+    const uniqueEmail = `testuser+${Date.now()}@example.com`;
+    await page.locator('#name').fill('Test User');
+    await page.locator('#email').fill(uniqueEmail);
+    await page.locator('#password').fill('password123');
+    await page.locator('#confirm-password').fill('password123');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('duplicate email shows error message', async ({ page }) => {
+    await page.locator('#name').fill('Duplicate User');
+    await page.locator('#email').fill(TEST_USER.email);
+    await page.locator('#password').fill('password123');
+    await page.locator('#confirm-password').fill('password123');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('weak password (< 8 chars) shows validation error', async ({ page }) => {
+    await page.locator('#name').fill('Test User');
+    await page.locator('#email').fill('weaktest@example.com');
+    await page.locator('#password').fill('short');
+    await page.locator('#confirm-password').fill('short');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.bg-red-50')).toContainText(/8 characters/);
+  });
+
+  test('mismatched passwords show validation error', async ({ page }) => {
+    await page.locator('#name').fill('Test User');
+    await page.locator('#email').fill('mismatch@example.com');
+    await page.locator('#password').fill('password123');
+    await page.locator('#confirm-password').fill('different456');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.bg-red-50')).toContainText(/do not match/i);
+  });
+
+  test('empty fields prevent submission (browser validation)', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await expect(page).toHaveURL(/\/signup/);
+  });
+});
+
+// ─── Logout ───────────────────────────────────────────────────────────────────
+
+test.describe('Logout', () => {
+  test('logout clears session and redirects to /login', async ({ page }) => {
+    await loginAs(page);
+    // The user avatar button in the header is the DropdownMenuTrigger;
+    // Radix sets aria-haspopup="menu" on the trigger element.
+    await page.locator('header [aria-haspopup="menu"]').click();
+    await page.getByRole('menuitem', { name: 'Logout' }).click();
+    await page.waitForURL('**/login', { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+// ─── Session Persistence ──────────────────────────────────────────────────────
+
+test.describe('Session Persistence', () => {
+  test('authenticated session survives page reload', async ({ page }) => {
+    await loginAs(page);
+    // Use domcontentloaded — the dashboard has background activity that prevents networkidle
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    // If session is persisted, dashboard does not redirect to /login
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});
+
+// ─── Admin Access ─────────────────────────────────────────────────────────────
+
+test.describe('Admin Access', () => {
+  test('unauthenticated user visiting /admin is redirected to /login', async ({ page }) => {
+    await page.goto('/admin');
+    await page.waitForURL('**/login', { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('non-admin user visiting /admin is redirected to /dashboard', async ({ page }) => {
+    // Sign up a fresh user — new accounts are non-admin by default
+    const uniqueEmail = `nonadmin+${Date.now()}@example.com`;
+    await page.goto('/signup');
+    await page.waitForLoadState('networkidle');
+    await page.locator('#name').fill('Non Admin User');
+    await page.locator('#email').fill(uniqueEmail);
+    await page.locator('#password').fill('password123');
+    await page.locator('#confirm-password').fill('password123');
+    await page.getByRole('button', { name: 'Create Account' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15_000 });
+
+    await page.goto('/admin');
+    await page.waitForURL('**/dashboard', { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('admin user can access /admin panel', async ({ page }) => {
+    await loginAs(page);
+    await page.goto('/admin');
+    await page.waitForURL('**/admin**', { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/admin/);
+  });
+});
+
+// ─── Forgot Password ──────────────────────────────────────────────────────────
+
+test.describe('Forgot Password', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/forgot-password');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('known email shows confirmation message', async ({ page }) => {
+    await page.locator('#email').fill(TEST_USER.email);
+    await page.getByRole('button', { name: 'Send reset link' }).click();
+    await expect(page.locator('.bg-green-50')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.bg-green-50')).toContainText('Check your inbox');
+  });
+
+  test('unknown email shows same confirmation (no user enumeration)', async ({ page }) => {
+    await page.locator('#email').fill('nobody_unknown@nonexistent.example.com');
+    await page.getByRole('button', { name: 'Send reset link' }).click();
+    // Better Auth returns the same success response for unknown emails to
+    // prevent email enumeration attacks.
+    await expect(page.locator('.bg-green-50')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.bg-green-50')).toContainText('Check your inbox');
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,46 @@
+import { type Page, expect } from '@playwright/test';
+
+export const TEST_USER = {
+  email: process.env.TEST_USER_EMAIL ?? 'habibjutt868@gmail.com',
+  password: process.env.TEST_USER_PASSWORD ?? '12345678',
+  name: 'Habib',
+};
+
+/** Log in via the UI and wait for the dashboard. */
+export async function loginAs(
+  page: Page,
+  email = TEST_USER.email,
+  password = TEST_USER.password,
+) {
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+  await page.locator('#email').fill(email);
+  await page.locator('#password').fill(password);
+  await page.getByRole('button', { name: 'Login' }).click();
+  await page.waitForURL('**/dashboard', { timeout: 15_000 });
+}
+
+/**
+ * Log out via the header user dropdown.
+ * Opens the Radix DropdownMenu trigger (aria-haspopup="menu") in the header,
+ * then clicks the "Logout" menu item.
+ */
+export async function logout(page: Page) {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle');
+  // Open user dropdown — Radix DropdownMenuTrigger adds aria-haspopup="menu"
+  await page.locator('header [aria-haspopup="menu"]').click();
+  await page.getByRole('menuitem', { name: 'Logout' }).click();
+  await page.waitForURL('**/login', { timeout: 10_000 });
+}
+
+/**
+ * Assert a visible error message on the page.
+ * Auth forms render errors in a div with class bg-red-50.
+ */
+export async function expectError(page: Page, text: string | RegExp) {
+  const alert = page
+    .locator('[role="alert"], .bg-red-50, .text-destructive, .text-red-500')
+    .filter({ hasText: text });
+  await expect(alert.first()).toBeVisible({ timeout: 8_000 });
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
+ *
+ * Auth credentials for the test user:
+ *   TEST_USER_EMAIL    (defaults to habibjutt868@gmail.com)
+ *   TEST_USER_PASSWORD (defaults to 12345678)
  */
+
+const authFile = path.join(__dirname, 'playwright/.auth/user.json');
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -16,9 +24,29 @@ export default defineConfig({
   },
 
   projects: [
+    // 1. Authenticate once and persist session state to disk.
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // 2. Auth flow tests — must start unauthenticated, no stored session.
+    {
+      name: 'auth-flows',
+      testMatch: /auth\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // 3. All other tests — reuse the saved session so login is skipped.
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      testMatch: /ui-consistency\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: authFile,
+      },
+      dependencies: ['setup'],
     },
   ],
 


### PR DESCRIPTION
Closes #22

## What's in this PR

Comprehensive Playwright E2E test suite for all authentication flows.

### New files
| File | Purpose |
|---|---|
| `playwright.config.ts` | Defines three projects: `setup` (saves session), `auth-flows` (runs unauthenticated), `chromium` (reuses saved session) |
| `e2e/fixtures/auth.ts` | Reusable `loginAs()` / `logout()` helpers + `TEST_USER` constant (env-overridable) |
| `e2e/auth.setup.ts` | Authenticates once as the test user and persists storage state to disk |
| `e2e/auth.spec.ts` | 16 tests across 6 describe blocks (see below) |

### Test coverage

```
auth.spec.ts (16 tests — all passing)
├── Login
│   ├── ✅ valid credentials redirect to /dashboard
│   ├── ✅ wrong password shows error message
│   ├── ✅ non-existent email shows error message
│   └── ✅ empty fields prevent submission (browser validation)
├── Signup
│   ├── ✅ valid new account redirects to /dashboard
│   ├── ✅ duplicate email shows error message
│   ├── ✅ weak password (< 8 chars) shows validation error
│   ├── ✅ mismatched passwords show validation error
│   └── ✅ empty fields prevent submission (browser validation)
├── Logout
│   └── ✅ clears session and redirects to /login
├── Session Persistence
│   └── ✅ authenticated session survives page reload
├── Admin Access
│   ├── ✅ unauthenticated user visiting /admin → redirected to /login
│   ├── ✅ non-admin user visiting /admin → redirected to /dashboard
│   └── ✅ admin user can access /admin panel
└── Forgot Password
    ├── ✅ known email shows confirmation message
    └── ✅ unknown email shows same confirmation (no user enumeration)
```

### Notable implementation decisions

- **Wrong password timing fix** — under parallel workers the auth request can take >8 s. The test now waits for the submit button to re-enable (request complete) before asserting the error banner, making it reliably fast without an arbitrary sleep.
- **Session persistence fix** — the dashboard has background network activity that prevents `networkidle` from resolving. Switched to `domcontentloaded` on reload.
- **Admin denial via fresh signup** — the non-admin test signs up a timestamp-unique user (non-admin by default) rather than relying on a fixed second test account, so it works on any environment.
- **Test credentials** are read from `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` env vars with fallback to the default dev account.