### PR TITLE
perf(db): add composite indexes for common query patterns

### DIFF
--- a/prisma/migrations/20260323072804_add_indexes/migration.sql
+++ b/prisma/migrations/20260323072804_add_indexes/migration.sql
@@ -1,0 +1,20 @@
+-- CreateIndex
+CREATE INDEX "audit_log_userId_createdAt_idx" ON "audit_log"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "invoice_creditCardId_isPaid_idx" ON "invoice"("creditCardId", "isPaid");
+
+-- CreateIndex
+CREATE INDEX "invoice_creditCardId_billStartDate_idx" ON "invoice"("creditCardId", "billStartDate");
+
+-- CreateIndex
+CREATE INDEX "spending_limit_userId_month_year_idx" ON "spending_limit"("userId", "month", "year");
+
+-- CreateIndex
+CREATE INDEX "transaction_creditCardId_createdAt_idx" ON "transaction"("creditCardId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "transaction_bankAccountId_createdAt_idx" ON "transaction"("bankAccountId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "transaction_category_idx" ON "transaction"("category");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,6 +162,10 @@ model invoice {
   paidFromBankAccount bank_account? @relation(fields: [paidFromBankAccountId], references: [id], onDelete: SetNull)
 
   @@unique([creditCardId, billStartDate, billEndDate])
+  // Composite indexes: filter by card+status and card+date range (common dashboard queries)
+  @@index([creditCardId, isPaid])
+  @@index([creditCardId, billStartDate])
+  // Kept individual indexes for backward compat / single-column lookups
   @@index([creditCardId])
   @@index([isPaid])
 }
@@ -187,10 +191,15 @@ model transaction {
   parentTransaction transaction? @relation("InstallmentRelation", fields: [parentTransactionId], references: [id], onDelete: Cascade)
   childTransactions transaction[] @relation("InstallmentRelation")
 
+  // Composite indexes for common query patterns: filter by account + sort by date
+  @@index([creditCardId, createdAt])
+  @@index([bankAccountId, createdAt])
+  // Kept individual indexes for FK lookups / installment traversal
   @@index([creditCardId])
   @@index([bankAccountId])
   @@index([date])
   @@index([parentTransactionId])
+  @@index([category])
 }
 
 model category {
@@ -222,6 +231,8 @@ model spending_limit {
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, categoryName, month, year])
+  // Composite index: look up limits for a specific user+month+year (most common pattern)
+  @@index([userId, month, year])
   @@index([userId])
 }
 
@@ -255,6 +266,8 @@ model audit_log {
 
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  // Composite index: list a user's audit history sorted by time (most common admin query)
+  @@index([userId, createdAt])
   @@index([userId])
   @@index([action])
   @@index([createdAt])


### PR DESCRIPTION
Closes #52

## What's in this PR

Adds all missing `@@index` declarations to `prisma/schema.prisma` and applies them through a single migration (`20260323072804_add_indexes`).

### Migration SQL — 7 new indexes

```sql
-- Composite: list card transactions sorted by date
CREATE INDEX "transaction_creditCardId_createdAt_idx"   ON "transaction"("creditCardId", "createdAt");

-- Composite: list account transactions sorted by date
CREATE INDEX "transaction_bankAccountId_createdAt_idx"  ON "transaction"("bankAccountId", "createdAt");

-- Filter transactions by category name
CREATE INDEX "transaction_category_idx"                 ON "transaction"("category");

-- Composite: unpaid/paid invoices per card (dashboard card view)
CREATE INDEX "invoice_creditCardId_isPaid_idx"          ON "invoice"("creditCardId", "isPaid");

-- Composite: date-range invoice queries per card
CREATE INDEX "invoice_creditCardId_billStartDate_idx"   ON "invoice"("creditCardId", "billStartDate");

-- Composite: monthly spending-limit lookup without category filter
CREATE INDEX "spending_limit_userId_month_year_idx"     ON "spending_limit"("userId", "month", "year");

-- Composite: user audit history sorted by time (admin panel)
CREATE INDEX "audit_log_userId_createdAt_idx"           ON "audit_log"("userId", "createdAt");
```

### Schema adaptations (vs. issue wording)

| Issue requirement | Actual schema | Resolution |
|---|---|---|
| `transaction (userId, createdAt)` | No `userId` column — access is through `creditCard`/`bankAccount` | Covered by `(creditCardId, createdAt)` + `(bankAccountId, createdAt)` |
| `transaction (categoryId)` | `category` is a `String`, not an FK | `@@index([category])` |
| `invoice (creditCardId, status)` | Field is `isPaid Boolean`, not `status` | `@@index([creditCardId, isPaid])` |
| `invoice (userId, billStartDate)` | No `userId` column on `invoice` | `@@index([creditCardId, billStartDate])` |
| `session (userId)` | Already present | No change needed |

### Verified

- ✅ `prisma migrate dev` applied cleanly against Neon DB
- ✅ `prisma generate` succeeded (client in sync)
- ✅ `npm run build` passes with no TypeScript errors