### PR TITLE
feat: track and display password last changed date

### DIFF
--- a/apps/web/app/(protected)/settings/page.tsx
+++ b/apps/web/app/(protected)/settings/page.tsx
@@ -28,6 +28,7 @@ import ChangePasswordModal from "@/components/change-password-modal";
 import DeleteAccountModal from "@/components/delete-account-modal";
 import { SUPPORTED_CURRENCIES } from "@/lib/utils";
 import { updatePreferredCurrency, updateBillReminderDays, getUserProfile } from "@/app/api/user-action";
+import { formatDistanceToNow } from "date-fns";
 import { FormCombobox } from "@/components/ui/form-combobox";
 
 type AlertState = { type: "success" | "error"; message: string } | null;
@@ -79,6 +80,7 @@ export default function SettingsPage() {
 
   const [billReminderDays, setBillReminderDays] = useState<number>(1);
   const [savingReminder, setSavingReminder] = useState(false);
+  const [passwordChangedAt, setPasswordChangedAt] = useState<Date | null>(null);
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -100,6 +102,9 @@ export default function SettingsPage() {
     getUserProfile().then((profile) => {
       if (profile?.billReminderDays !== undefined) {
         setBillReminderDays(profile.billReminderDays);
+      }
+      if (profile?.passwordChangedAt) {
+        setPasswordChangedAt(new Date(profile.passwordChangedAt));
       }
     });
   }, [session]);
@@ -284,7 +289,10 @@ export default function SettingsPage() {
                 <div>
                   <p className="text-sm font-medium text-slate-800">Password</p>
                   <p className="text-xs text-slate-500 mt-0.5">
-                    Last changed: not tracked
+                    Last changed:{" "}
+                    {passwordChangedAt
+                      ? formatDistanceToNow(passwordChangedAt, { addSuffix: true })
+                      : "never"}
                   </p>
                 </div>
                 <Button
@@ -457,6 +465,7 @@ export default function SettingsPage() {
       <ChangePasswordModal
         open={showPasswordModal}
         setOpen={setShowPasswordModal}
+        onSuccess={() => setPasswordChangedAt(new Date())}
       />
       <DeleteAccountModal
         open={showDeleteModal}

--- a/apps/web/app/api/user-action.ts
+++ b/apps/web/app/api/user-action.ts
@@ -39,6 +39,7 @@ export async function getUserProfile() {
         preferredCurrency: true,
         billReminderDays: true,
         name: true,
+        passwordChangedAt: true,
       },
     }),
     getUserPlanLimits(session.user.id),
@@ -46,6 +47,19 @@ export async function getUserProfile() {
 
   if (!user) return null;
   return { ...user, planLimits };
+}
+
+export async function recordPasswordChanged() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) return { error: "Unauthorized" };
+
+  await db.user.update({
+    where: { id: session.user.id },
+    data: { passwordChangedAt: new Date() },
+  });
+
+  revalidatePath("/settings");
+  return { success: true };
 }
 
 export async function updateBillReminderDays(days: number) {

--- a/apps/web/components/change-password-modal.tsx
+++ b/apps/web/components/change-password-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { changePassword } from "@/lib/auth-client";
+import { recordPasswordChanged } from "@/app/api/user-action";
 import {
   Dialog,
   DialogContent,
@@ -16,11 +17,13 @@ import { Button } from "@/components/ui/button";
 interface ChangePasswordModalProps {
   open: boolean;
   setOpen: (open: boolean) => void;
+  onSuccess?: () => void;
 }
 
 export default function ChangePasswordModal({
   open,
   setOpen,
+  onSuccess,
 }: ChangePasswordModalProps) {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -65,7 +68,8 @@ export default function ChangePasswordModal({
           revokeOtherSessions: true,
         },
         {
-          onSuccess: () => {
+          onSuccess: async () => {
+            await recordPasswordChanged();
             setSuccess(true);
             setCurrentPassword("");
             setNewPassword("");
@@ -73,6 +77,7 @@ export default function ChangePasswordModal({
             setTimeout(() => {
               setOpen(false);
               setSuccess(false);
+              onSuccess?.();
             }, 2000);
           },
           onError: (ctx) => {

--- a/apps/web/prisma/migrations/20260512111511_add_password_changed_at/migration.sql
+++ b/apps/web/prisma/migrations/20260512111511_add_password_changed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "passwordChangedAt" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -45,6 +45,7 @@ model user {
 
   preferredCurrency    String    @default("AED")
   onboardingCompleted  Boolean   @default(false)
+  passwordChangedAt    DateTime?
   billReminderDays     Int       @default(1) // Days before invoice due date to send email reminder (0 = same day)
 
   accounts account[]


### PR DESCRIPTION
- Add passwordChangedAt DateTime? field to user model
- Migration: 20260512111511_add_password_changed_at
- Add recordPasswordChanged() server action
- Call recordPasswordChanged() in ChangePasswordModal on success
- Add onSuccess prop to ChangePasswordModal to update UI without refetch
- Display relative time (date-fns formatDistanceToNow) in Security section
- Falls back to 'never' if password was never changed via the app

Closes #113